### PR TITLE
For UT development work

### DIFF
--- a/aliyun-net-sdk-core.Tests/aliyun-net-sdk-core-unit-tests.csproj
+++ b/aliyun-net-sdk-core.Tests/aliyun-net-sdk-core-unit-tests.csproj
@@ -4,6 +4,7 @@
     <TargetFramework>netcoreapp2.1</TargetFramework>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
     <IsPackable>false</IsPackable>
+    <AssemblyName>aliyun-net-sdk-core.Tests</AssemblyName>
   </PropertyGroup>
 
   <ItemGroup>

--- a/aliyun-net-sdk-core/Profile/DefaultProfile.cs
+++ b/aliyun-net-sdk-core/Profile/DefaultProfile.cs
@@ -319,5 +319,11 @@ namespace Aliyun.Acs.Core.Profile
             }
             credential = new CredentialsBackupCompatibilityAdaptor(credentialsProvider);
         }
+
+        public static void ClearDefaultProfile()
+        {
+            profile = null;
+            endpoints = null;
+        }
     }
 }


### PR DESCRIPTION
DefaultProfile 增加静态变量释放方法，用以解决UT之间的数据干扰问题。

UT项目工程文件增加AssemblyName属性，
用以在后续引用Core中internal类时，声明友元程序集，从而解决internal类无法引用的问题。