### PR TITLE
签名错误码改进，增加IncompleteSignature错误码

### DIFF
--- a/aliyun-net-sdk-core.Tests/Units/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core.Tests/Units/DefaultAcsClient.cs
@@ -242,6 +242,31 @@ namespace Aliyun.Acs.Core.Tests.Units
         }
 
         [Fact]
+        public void TestIncompleteSignature()
+        {
+            DefaultAcsClient instance = this.MockDefaultAcsClient(400, "IncompleteSignature", "The request signature does not conform to Aliyun standards. server string to sign is:Error Signature");
+            MockAcsRequestForDefaultAcsClient request = new MockAcsRequestForDefaultAcsClient();
+            request.StringToSign = "this is string to sign info";
+            Credential credentials = new Credential(AKID, AKSE);
+
+            Exception signatureException = Assert.Throws<ClientException>(() =>
+            {
+                var result = instance.GetAcsResponse<AcsResponse>(request, "cn-hangzhou", credentials);
+            });
+
+            Assert.Equal("IncompleteSignature : The request signature does not conform to Aliyun standards. server string to sign is:Error Signature", signatureException.Message);
+
+            instance = this.MockDefaultAcsClient(400, "IncompleteSignature", "The request signature does not conform to Aliyun standards. server string to sign is:this is string to sign info");
+
+            Exception invalidException = Assert.Throws<ClientException>(() =>
+            {
+                var result = instance.GetAcsResponse<AcsResponse>(request, "cn-hangzhou", credentials);
+            });
+
+            Assert.Equal("SDK.InvalidAccessKeySecret : Specified Access Key Secret is not valid.", invalidException.Message);
+        }
+
+        [Fact]
         public void GetCommonResponse()
         {
             int status = 200;

--- a/aliyun-net-sdk-core/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core/DefaultAcsClient.cs
@@ -127,7 +127,7 @@ namespace Aliyun.Acs.Core
                     }
                     else
                     {
-                        if (400 == httpResponse.Status && error.ErrorCode.Equals("SignatureDoesNotMatch"))
+                        if (400 == httpResponse.Status && (error.ErrorCode.Equals("SignatureDoesNotMatch") || error.ErrorCode.Equals("IncompleteSignature")))
                         {
                             var errorMessage = error.ErrorMessage;
                             Regex re = new Regex(@"string to sign is:", RegexOptions.Compiled | RegexOptions.IgnoreCase);


### PR DESCRIPTION
http状态码为400，且 code 为 SignatureDoesNotMatch或IncompleteSignature 时，进一步判断客户端 StringToSign 和服务端 StringToSign 是否一致。如果一致，则提示 InvalidAccessKeySecret 错误。
