### PR TITLE
Endpoints rule upgrade

### DIFF
--- a/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
+++ b/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
@@ -31,6 +31,32 @@ namespace Aliyun.Acs.Core.Tests.Units
     public class AcsRequestTest
     {
         [Fact]
+        public void GetEndpoint()
+        {
+            var mockAcsRequest = new MockAcsRequest();
+            Assert.Equal("", mockAcsRequest.GetProductEndpoint());
+
+            Dictionary<string, string> endpointMap = new Dictionary<string, string> { };
+            endpointMap.Add("cn-hangzhou", "test.cn-hangzhou.aliyuncs.com");
+
+            mockAcsRequest.ProductEndpointMap = endpointMap;
+            mockAcsRequest.ProductEndpointType = "region";
+
+            mockAcsRequest.RegionId = "cn-hangzhou";
+            Assert.Equal("test.cn-hangzhou.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.Product = "test";
+            mockAcsRequest.RegionId = "cn-beijing";
+            Assert.Equal("test.cn-beijing.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.ProductEndpointType = "center";
+            Assert.Equal("test.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.ProductNetwork = "vpc";
+            Assert.Equal("test-vpc.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+        }
+
+        [Fact]
         public void CheckShowJsonItemName()
         {
             var mockAcsRequest = new MockAcsRequest();
@@ -52,13 +78,13 @@ namespace Aliyun.Acs.Core.Tests.Units
             // when parameters is empty
             tmpDic = new Dictionary<string, string>();
             result = MockAcsRequest.ConcatQueryString(tmpDic);
-            
+
             // Get the empty not null
             Assert.NotNull(result);
             Assert.Empty(result);
 
             // When parammters is not null
-            tmpDic = new Dictionary<string, string> {{"foo", "bar"}, {"a", "A"}, {"n", null}};
+            tmpDic = new Dictionary<string, string> { { "foo", "bar" }, { "a", "A" }, { "n", null } };
             result = MockAcsRequest.ConcatQueryString(tmpDic);
             Assert.Equal("foo=bar&a=A&n", result);
         }
@@ -79,7 +105,7 @@ namespace Aliyun.Acs.Core.Tests.Units
         {
             var mockAcsRequest = new MockAcsRequest();
 
-            var tmpDic = new Dictionary<string, string> {{"foo", "bar"}};
+            var tmpDic = new Dictionary<string, string> { { "foo", "bar" } };
             mockAcsRequest.QueryParameters = tmpDic;
 
             mockAcsRequest.DomainParameters = tmpDic;
@@ -92,7 +118,7 @@ namespace Aliyun.Acs.Core.Tests.Units
         [Fact]
         public void SignRequest()
         {
-            var tmpDic = new Dictionary<string, string> {{"foo", "bar"}, {"a", "A"}, {"n", null}};
+            var tmpDic = new Dictionary<string, string> { { "foo", "bar" }, { "a", "A" }, { "n", null } };
 
             var mockAcsRequest = new MockAcsRequest("https://www.alibabacloud.com/");
             var signer = new HmacSHA1Signer();
@@ -122,9 +148,7 @@ namespace Aliyun.Acs.Core.Tests.Units
 
     public sealed class MockAcsRequest : AcsRequest<CommonRequest>
     {
-        public MockAcsRequest(string urlStr = null) : base(urlStr)
-        {
-        }
+        public MockAcsRequest(string urlStr = null) : base(urlStr) { }
 
         public override HttpRequest SignRequest(Signer signer, AlibabaCloudCredentials credentials,
             FormatType? format, ProductDomain domain)

--- a/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
+++ b/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
@@ -45,7 +45,7 @@ namespace Aliyun.Acs.Core.Tests.Units
             mockAcsRequest.RegionId = "cn-hangzhou";
             Assert.Equal("test.cn-hangzhou.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
 
-            mockAcsRequest.Product = "test";
+            mockAcsRequest.Product = "Test";
             mockAcsRequest.RegionId = "cn-beijing";
             Assert.Equal("test.cn-beijing.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
 

--- a/aliyun-net-sdk-core/AcsRequest.cs
+++ b/aliyun-net-sdk-core/AcsRequest.cs
@@ -32,7 +32,6 @@ namespace Aliyun.Acs.Core
     {
         private FormatType acceptFormat;
 
-
         public string StringToSign;
         private UserAgent userAgentConfig;
 
@@ -41,6 +40,13 @@ namespace Aliyun.Acs.Core
             DictionaryUtil.Add(Headers, "x-sdk-client", "Net/2.0.0");
             DictionaryUtil.Add(Headers, "x-sdk-invoke-type", "normal");
             Product = product;
+            string endpoint = GetProductEndpoint();
+            if (endpoint != "")
+            {
+                ProductDomain = new ProductDomain();
+                ProductDomain.ProductName = product;
+                ProductDomain.DomianName = endpoint;
+            }
         }
 
         public virtual string Product { get; set; }
@@ -52,6 +58,55 @@ namespace Aliyun.Acs.Core
         public string LocationProduct { get; set; }
         public string LocationEndpointType { get; set; }
         public ProductDomain ProductDomain { get; set; }
+
+        public Dictionary<string, string> ProductEndpointMap { get; set; }
+
+        public string ProductEndpointType { get; set; }
+
+        public string ProductNetwork = "public";
+
+        public virtual string GetProductEndpoint()
+        {
+            if (ProductEndpointMap == null && ProductEndpointType == null)
+            {
+                return "";
+            }
+
+            foreach (var endpoint in ProductEndpointMap)
+            {
+                if (endpoint.Key == RegionId)
+                {
+                    return endpoint.Value;
+                }
+            }
+
+            string Rule = "";
+            if (ProductEndpointType == "center")
+            {
+                Rule = "<product_id><network>.aliyuncs.com";
+            }
+            else if (ProductEndpointType == "region")
+            {
+                Rule = "<product_id><network>.<region_id>.aliyuncs.com";
+                Rule = Rule.Replace("<region_id>", RegionId);
+            }
+
+            if (Rule == "")
+            {
+                return "";
+            }
+
+            Rule = Rule.Replace("<product_id>", Product);
+            if (ProductNetwork == "public")
+            {
+                Rule = Rule.Replace("<network>", "");
+            }
+            else
+            {
+                Rule = Rule.Replace("<network>", "-" + ProductNetwork);
+            }
+            return Rule;
+        }
 
         public virtual FormatType AcceptFormat
         {

--- a/aliyun-net-sdk-core/AcsRequest.cs
+++ b/aliyun-net-sdk-core/AcsRequest.cs
@@ -100,7 +100,7 @@ namespace Aliyun.Acs.Core
                 return "";
             }
 
-            Rule = Rule.Replace("<product_id>", Product);
+            Rule = Rule.Replace("<product_id>", Product.ToLower());
             if (ProductNetwork == "public")
             {
                 Rule = Rule.Replace("<network>", "");

--- a/aliyun-net-sdk-core/AcsRequest.cs
+++ b/aliyun-net-sdk-core/AcsRequest.cs
@@ -69,6 +69,13 @@ namespace Aliyun.Acs.Core
             }
         }
 
+        public void SetEndpoint(string endpoint)
+        {
+            ProductDomain = new ProductDomain();
+            ProductDomain.ProductName = Product;
+            ProductDomain.DomianName = endpoint;
+        }
+
         public virtual string GetProductEndpoint()
         {
             if (ProductEndpointMap == null && ProductEndpointType == null)

--- a/aliyun-net-sdk-core/AcsRequest.cs
+++ b/aliyun-net-sdk-core/AcsRequest.cs
@@ -40,13 +40,6 @@ namespace Aliyun.Acs.Core
             DictionaryUtil.Add(Headers, "x-sdk-client", "Net/2.0.0");
             DictionaryUtil.Add(Headers, "x-sdk-invoke-type", "normal");
             Product = product;
-            string endpoint = GetProductEndpoint();
-            if (endpoint != "")
-            {
-                ProductDomain = new ProductDomain();
-                ProductDomain.ProductName = product;
-                ProductDomain.DomianName = endpoint;
-            }
         }
 
         public virtual string Product { get; set; }
@@ -64,6 +57,17 @@ namespace Aliyun.Acs.Core
         public string ProductEndpointType { get; set; }
 
         public string ProductNetwork = "public";
+
+        public void SetProductDomain()
+        {
+            string endpoint = GetProductEndpoint();
+            if (endpoint != "")
+            {
+                ProductDomain = new ProductDomain();
+                ProductDomain.ProductName = Product;
+                ProductDomain.DomianName = endpoint;
+            }
+        }
 
         public virtual string GetProductEndpoint()
         {

--- a/aliyun-net-sdk-core/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core/DefaultAcsClient.cs
@@ -172,6 +172,7 @@ namespace Aliyun.Acs.Core
             {
                 request.RegionId = regionId;
             }
+            request.SetProductDomain();
 
             List<Endpoint> endpoints = null;
             if (null != clientProfile)
@@ -205,6 +206,7 @@ namespace Aliyun.Acs.Core
             {
                 request.RegionId = region;
             }
+            request.SetProductDomain();
 
             var credentials = credentialsProvider.GetCredentials();
             if (credentials == null)

--- a/aliyun-net-sdk-core/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core/DefaultAcsClient.cs
@@ -122,7 +122,7 @@ namespace Aliyun.Acs.Core
         }
 
         public T GetAcsResponse<T>(AcsRequest<T> request, string regionId, Credential credential)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             var httpResponse = DoAction(request, regionId, credential);
             return ParseAcsResponse(request, httpResponse);
@@ -153,7 +153,7 @@ namespace Aliyun.Acs.Core
         }
 
         public HttpResponse DoAction<T>(AcsRequest<T> request, bool autoRetry, int maxRetryNumber)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             return DoAction(request, autoRetry, maxRetryNumber, clientProfile);
         }
@@ -164,7 +164,7 @@ namespace Aliyun.Acs.Core
         }
 
         public HttpResponse DoAction<T>(AcsRequest<T> request, string regionId, Credential credential)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             var signer = Signer.GetSigner(new LegacyCredentials(credential));
             FormatType? format = null;
@@ -177,9 +177,12 @@ namespace Aliyun.Acs.Core
             if (null != clientProfile)
             {
                 format = clientProfile.GetFormat();
-                endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
-                    request.LocationProduct,
-                    request.LocationEndpointType);
+                if (request.ProductDomain == null)
+                {
+                    endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
+                        request.LocationProduct,
+                        request.LocationEndpointType);
+                }
             }
 
             return DoAction(request, AutoRetry, MaxRetryNumber, request.RegionId, credential, signer,
@@ -211,11 +214,14 @@ namespace Aliyun.Acs.Core
 
             var signer = Signer.GetSigner(credentials);
             var format = profile.GetFormat();
-            List<Endpoint> endpoints;
+            List<Endpoint> endpoints = null;
 
-            endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
-                request.LocationProduct,
-                request.LocationEndpointType);
+            if (request.ProductDomain == null)
+            {
+                endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
+                    request.LocationProduct,
+                    request.LocationEndpointType);
+            }
 
             return DoAction(request, retry, retryNumber, request.RegionId, credentials, signer, format, endpoints);
         }
@@ -248,7 +254,7 @@ namespace Aliyun.Acs.Core
                     }
 
                     if (400 == httpResponse.Status && (error.ErrorCode.Equals("SignatureDoesNotMatch") ||
-                                                       error.ErrorCode.Equals("IncompleteSignature")))
+                            error.ErrorCode.Equals("IncompleteSignature")))
                     {
                         var errorMessage = error.ErrorMessage;
                         var re = new Regex(@"string to sign is:", RegexOptions.Compiled | RegexOptions.IgnoreCase);
@@ -288,7 +294,7 @@ namespace Aliyun.Acs.Core
         public virtual HttpResponse DoAction<T>(AcsRequest<T> request, bool autoRetry, int maxRetryNumber,
             string regionId,
             AlibabaCloudCredentials credentials, Signer signer, FormatType? format, List<Endpoint> endpoints)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             try
             {
@@ -387,7 +393,7 @@ namespace Aliyun.Acs.Core
         }
 
         private T ReadResponse<T>(AcsRequest<T> request, HttpResponse httpResponse, FormatType? format)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             var reader = ReaderFactory.CreateInstance(format);
             var context = new UnmarshallerContext();
@@ -407,7 +413,7 @@ namespace Aliyun.Acs.Core
         }
 
         private AcsError ReadError<T>(AcsRequest<T> request, HttpResponse httpResponse, FormatType? format)
-            where T : AcsResponse
+        where T : AcsResponse
         {
             var responseEndpoint = "Error";
             var reader = ReaderFactory.CreateInstance(format);
@@ -500,7 +506,7 @@ namespace Aliyun.Acs.Core
         public string GetHttpProxy()
         {
             return WebProxy.HttpProxy ?? Environment.GetEnvironmentVariable("HTTP_PROXY") ??
-                   Environment.GetEnvironmentVariable("http_proxy");
+                Environment.GetEnvironmentVariable("http_proxy");
         }
 
         /// <summary>
@@ -510,7 +516,7 @@ namespace Aliyun.Acs.Core
         public string GetHttpsProxy()
         {
             return WebProxy.HttpsProxy ?? Environment.GetEnvironmentVariable("HTTPS_PROXY") ??
-                   Environment.GetEnvironmentVariable("https_proxy");
+                Environment.GetEnvironmentVariable("https_proxy");
         }
 
         /// <summary>
@@ -520,7 +526,7 @@ namespace Aliyun.Acs.Core
         public string GetNoProxy()
         {
             return WebProxy.NoProxy ?? Environment.GetEnvironmentVariable("NO_PROXY") ??
-                   Environment.GetEnvironmentVariable("no_proxy");
+                Environment.GetEnvironmentVariable("no_proxy");
         }
 
         private void ResolveProxy<T>(HttpRequest httpRequest, AcsRequest<T> request) where T : AcsResponse


### PR DESCRIPTION
1. 增加 AcsRequestTest.GetEndpoint() 单元测试。
2. 支持新的 endpoints 数据规则的使用。

原理：
增加 `AcsRequest.GetProductEndpoint()`方法，根据新的 endpoints 规则数据进行 endpoint 寻址。
增加 `AcsRequest.SetProductDomain()`方法，进行  AcsRequest.ProductDomain 属性的初始化。

若初始化成功，则 ProductDomain 属性不为 `null`，初始化不成功，则 ProductDomain 属性为 `null`。
DefaultAcsClient 中判断 request 的 ProductDomain 不为 null 时，即已经被成功初始化后，直接使用ProductDomain 中的 DomainName 作为 endpoint。

