### PR TITLE
change: endpoints rule upgrade 

### DIFF
--- a/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
+++ b/aliyun-net-sdk-core.Tests/Units/AcsRequest.cs
@@ -52,15 +52,74 @@ namespace Aliyun.Acs.Core.Tests.Units
             // when parameters is empty
             tmpDic = new Dictionary<string, string>();
             result = MockAcsRequest.ConcatQueryString(tmpDic);
-            
+
             // Get the empty not null
             Assert.NotNull(result);
             Assert.Empty(result);
 
             // When parammters is not null
-            tmpDic = new Dictionary<string, string> {{"foo", "bar"}, {"a", "A"}, {"n", null}};
+            tmpDic = new Dictionary<string, string> { { "foo", "bar" }, { "a", "A" }, { "n", null } };
             result = MockAcsRequest.ConcatQueryString(tmpDic);
             Assert.Equal("foo=bar&a=A&n", result);
+        }
+
+        [Fact]
+        public void GetEndpoint()
+        {
+            var mockAcsRequest = new MockAcsRequest();
+            Assert.Equal("", mockAcsRequest.GetProductEndpoint());
+
+            var endpointMap = new Dictionary<string, string>();
+            endpointMap.Add("cn-hangzhou", "test.cn-hangzhou.aliyuncs.com");
+
+            mockAcsRequest.ProductEndpointMap = endpointMap;
+            mockAcsRequest.ProductEndpointType = "regional";
+
+            mockAcsRequest.RegionId = "cn-hangzhou";
+            Assert.Equal("test.cn-hangzhou.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.Product = "Test";
+            mockAcsRequest.RegionId = "cn-beijing";
+            Assert.Equal("test.cn-beijing.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.ProductEndpointType = "central";
+            Assert.Equal("test.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            mockAcsRequest.ProductNetwork = "vpc";
+            Assert.Equal("test-vpc.aliyuncs.com", mockAcsRequest.GetProductEndpoint());
+
+            var productEndpointMap = new Dictionary<string, string>();
+            mockAcsRequest.ProductEndpointType = "test-type";
+            mockAcsRequest.ProductEndpointMap = productEndpointMap;
+
+            Assert.Empty(mockAcsRequest.GetProductEndpoint());
+        }
+
+        [Fact]
+        public void SetProductDomain()
+        {
+            var endpoint = "test.ecs.cn-hangzhou.aliyuncs.com";
+            var mockAcsRequest = new MockAcsRequest();
+
+            mockAcsRequest.SetProductDomain();
+            mockAcsRequest.SetProductDomain(endpoint);
+
+            Assert.Equal(endpoint, mockAcsRequest.ProductDomain.DomianName);
+
+            mockAcsRequest.ProductDomain = null;
+        }
+
+        [Fact]
+        public void SetEndpoint()
+        {
+            var endpoint = "ecs.cn-hangzhou.aliyuncs.com";
+
+            var mockAcsRequest = new MockAcsRequest();
+            mockAcsRequest.SetEndpoint(endpoint);
+
+            Assert.Equal(endpoint, mockAcsRequest.ProductDomain.DomianName);
+
+            mockAcsRequest.ProductDomain = null;
         }
 
         [Fact]
@@ -79,7 +138,7 @@ namespace Aliyun.Acs.Core.Tests.Units
         {
             var mockAcsRequest = new MockAcsRequest();
 
-            var tmpDic = new Dictionary<string, string> {{"foo", "bar"}};
+            var tmpDic = new Dictionary<string, string> { { "foo", "bar" } };
             mockAcsRequest.QueryParameters = tmpDic;
 
             mockAcsRequest.DomainParameters = tmpDic;
@@ -92,7 +151,7 @@ namespace Aliyun.Acs.Core.Tests.Units
         [Fact]
         public void SignRequest()
         {
-            var tmpDic = new Dictionary<string, string> {{"foo", "bar"}, {"a", "A"}, {"n", null}};
+            var tmpDic = new Dictionary<string, string> { { "foo", "bar" }, { "a", "A" }, { "n", null } };
 
             var mockAcsRequest = new MockAcsRequest("https://www.alibabacloud.com/");
             var signer = new HmacSHA1Signer();
@@ -122,9 +181,7 @@ namespace Aliyun.Acs.Core.Tests.Units
 
     public sealed class MockAcsRequest : AcsRequest<CommonRequest>
     {
-        public MockAcsRequest(string urlStr = null) : base(urlStr)
-        {
-        }
+        public MockAcsRequest(string urlStr = null) : base(urlStr) { }
 
         public override HttpRequest SignRequest(Signer signer, AlibabaCloudCredentials credentials,
             FormatType? format, ProductDomain domain)

--- a/aliyun-net-sdk-core/AcsRequest.cs
+++ b/aliyun-net-sdk-core/AcsRequest.cs
@@ -95,6 +95,78 @@ namespace Aliyun.Acs.Core
             set { bodyParameters = value; }
         }
 
+        public Dictionary<string, string> ProductEndpointMap { get; set; }
+
+        public string ProductEndpointType { get; set; }
+
+        public string ProductNetwork = "public";
+
+        public void SetProductDomain(string endpoint = "")
+        {
+            if (endpoint == "")
+            {
+                endpoint = GetProductEndpoint();
+            }
+
+            if (endpoint != "" && ProductDomain == null)
+            {
+                ProductDomain = new ProductDomain
+                {
+                ProductName = Product,
+                DomianName = endpoint
+                };
+            }
+        }
+
+        public void SetEndpoint(string endpoint)
+        {
+            ProductDomain = new ProductDomain
+            {
+                ProductName = Product,
+                DomianName = endpoint
+            };
+        }
+
+        public string GetProductEndpoint()
+        {
+            if (ProductEndpointMap == null && ProductEndpointType == null)
+            {
+                return "";
+            }
+
+            foreach (var endpointItem in ProductEndpointMap)
+            {
+                if (endpointItem.Key == RegionId)
+                {
+                    return endpointItem.Value;
+                }
+            }
+
+            var endpoint = "";
+            if (ProductEndpointType == "central")
+            {
+                endpoint = "<product_id><network>.aliyuncs.com";
+            }
+            else if (ProductEndpointType == "regional")
+            {
+                endpoint = "<product_id><network>.<region_id>.aliyuncs.com";
+                endpoint = endpoint.Replace("<region_id>", RegionId);
+            }
+
+            if (endpoint == "")
+            {
+                return "";
+            }
+
+            endpoint = endpoint.Replace("<product_id>", Product.ToLower());
+
+            endpoint = ProductNetwork == "public" ?
+                endpoint.Replace("<network>", "") :
+                endpoint.Replace("<network>", "-" + ProductNetwork);
+
+            return endpoint;
+        }
+
         public static string ConcatQueryString(Dictionary<string, string> parameters)
         {
             if (null == parameters)

--- a/aliyun-net-sdk-core/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core/DefaultAcsClient.cs
@@ -173,13 +173,18 @@ namespace Aliyun.Acs.Core
                 request.RegionId = regionId;
             }
 
+            request.SetProductDomain();
+
             List<Endpoint> endpoints = null;
             if (null != clientProfile)
             {
                 format = clientProfile.GetFormat();
-                endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
-                    request.LocationProduct,
-                    request.LocationEndpointType);
+                if (request.ProductDomain == null)
+                {
+                    endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
+                        request.LocationProduct,
+                        request.LocationEndpointType);
+                }
             }
 
             return DoAction(request, AutoRetry, MaxRetryNumber, request.RegionId, credential, signer,
@@ -203,6 +208,8 @@ namespace Aliyun.Acs.Core
                 request.RegionId = region;
             }
 
+            request.SetProductDomain();
+
             var credentials = credentialsProvider.GetCredentials();
             if (credentials == null)
             {
@@ -211,11 +218,14 @@ namespace Aliyun.Acs.Core
 
             var signer = Signer.GetSigner(credentials);
             var format = profile.GetFormat();
-            List<Endpoint> endpoints;
+            List<Endpoint> endpoints = null;
 
-            endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
-                request.LocationProduct,
-                request.LocationEndpointType);
+            if (request.ProductDomain == null)
+            {
+                endpoints = clientProfile.GetEndpoints(request.Product, request.RegionId,
+                    request.LocationProduct,
+                    request.LocationEndpointType);
+            }
 
             return DoAction(request, retry, retryNumber, request.RegionId, credentials, signer, format, endpoints);
         }


### PR DESCRIPTION
info:
增加 AcsRequestTest.GetEndpoint() 单元测试。
增加 AcsRequest.GetProductEndpoint()方法，支持新的 endpoints 数据规则的使用。
增加 AcsRequest.SetEndpoint() 方法，用户可使用此方法指定 Endpoint
原理：
增加 AcsRequest.GetProductEndpoint()方法，根据新的 endpoints 规则数据进行 endpoint 寻址。
增加 AcsRequest.SetProductDomain()方法，进行 AcsRequest.ProductDomain 属性的初始化。
增加 AcsRequest.SetEndpoint() 方法，直接对 AcsRequest.ProductDomain 属性进行赋值。

若 AcsRequest.ProductDomain 初始化成功，则 ProductDomain 属性不为 null，初始化不成功，则 ProductDomain 属性为 null。

DefaultAcsClient 中判断 request 的 ProductDomain 不为 null 时，直接使用 ProductDomain 中的 DomainName 作为 endpoint。