### PR TITLE
Core release version 1.5.2

### DIFF
--- a/aliyun-net-sdk-core/ChangeLog.md
+++ b/aliyun-net-sdk-core/ChangeLog.md
@@ -1,3 +1,11 @@
+### 2019-07-08 Version 1.5.2
+* Deprecated Newtonsoft.Json package
+* Convert json file to cs file
+* Fixed URL builder 
+* Thread safe
+* Remove net45 solution
+* use DateTime.UtcNow instead of DateTime.Now
+
 ### 2019-07-08 Version 1.5.1
 * Fix RequestId is empty in exception message
 * Fix content type will null error 

--- a/aliyun-net-sdk-core/Properties/AssemblyInfo.cs
+++ b/aliyun-net-sdk-core/Properties/AssemblyInfo.cs
@@ -28,5 +28,5 @@ using System.Runtime.InteropServices;
 //      Build Number
 //      Revision
 //
-[assembly: AssemblyVersion("1.5.1.0")]
-[assembly: AssemblyFileVersion("1.5.1.0")]
+[assembly: AssemblyVersion("1.5.2.0")]
+[assembly: AssemblyFileVersion("1.5.2.0")]

--- a/aliyun-net-sdk-core/aliyun-net-sdk-core.vs2017.csproj
+++ b/aliyun-net-sdk-core/aliyun-net-sdk-core.vs2017.csproj
@@ -3,7 +3,7 @@
   <PropertyGroup>
     <TargetFrameworks>netstandard2.0;net45</TargetFrameworks>
     <RootNamespace>Aliyun.Acs.Core</RootNamespace>
-    <Version>1.5.1</Version>
+    <Version>1.5.2</Version>
     <Authors>Alibaba Cloud</Authors>
     <PackageTags>alibaba aliyun SDK core</PackageTags>
     <Copyright>©2009-2019 Alibaba Cloud</Copyright>


### PR DESCRIPTION
* Deprecated Newtonsoft.Json package
* Convert json file to cs file
* Fixed URL builder 
* Thread safe
* Remove net45 solution
* use DateTime.UtcNow instead of DateTime.Now