### PR TITLE
fixed endpoint resolve.

### DIFF
--- a/aliyun-net-sdk-core.Tests/Units/Regions/EndpointUserConfig.cs
+++ b/aliyun-net-sdk-core.Tests/Units/Regions/EndpointUserConfig.cs
@@ -1,0 +1,59 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+
+using System.Collections.Generic;
+
+using Aliyun.Acs.Core.Regions;
+
+using Xunit;
+
+namespace Aliyun.Acs.Core.Tests.Units.Regions
+{
+    public class EndpointUserConfigTest
+    {
+        [Fact]
+        public void TestAddEndpoint()
+        {
+            string productId = "product_id";
+            string regionId = "region_id";
+            string domain = "mock_domain";
+            EndpointUserConfig.AddEndpoint(productId, regionId, domain);
+            ProductDomain productDomain = EndpointUserConfig.GetProductDomain(productId, regionId);
+            Assert.Equal(domain, productDomain.DomainName);
+            Assert.Equal(productId, productDomain.ProductName);
+        }
+
+        [Fact]
+        public void TestGetNotExistEndpoint()
+        {
+            ProductDomain productDomain = EndpointUserConfig.GetProductDomain("not_exist_product", "region_id");
+            Assert.Null(productDomain);
+        }
+
+        [Fact]
+        public void TestAddEndpointWithNullParam()
+        {
+            string productId = "mock_product_id";
+            string regionId = "mock_region_id";
+            EndpointUserConfig.AddEndpoint(productId, regionId, null);
+            ProductDomain productDomain = EndpointUserConfig.GetProductDomain(productId, regionId);
+            Assert.Null(productDomain);
+        }
+    }
+}

--- a/aliyun-net-sdk-core/DefaultAcsClient.cs
+++ b/aliyun-net-sdk-core/DefaultAcsClient.cs
@@ -178,7 +178,14 @@ namespace Aliyun.Acs.Core
                 request.RegionId = regionId;
             }
 
-            request.SetProductDomain();
+            if (request.ProductDomain == null)
+            {
+                request.ProductDomain = EndpointUserConfig.GetProductDomain(request.Product, request.RegionId);
+                if (request.ProductDomain == null)
+                {
+                    request.SetProductDomain();
+                }
+            }
 
             List<Endpoint> endpoints = null;
             if (null != clientProfile)
@@ -209,7 +216,14 @@ namespace Aliyun.Acs.Core
                 request.RegionId = region;
             }
 
-            request.SetProductDomain();
+            if (request.ProductDomain == null)
+            {
+                request.ProductDomain = EndpointUserConfig.GetProductDomain(request.Product, request.RegionId);
+                if (request.ProductDomain == null)
+                {
+                    request.SetProductDomain();
+                }
+            }
 
             var credentials = credentialsProvider.GetCredentials();
             if (credentials == null)

--- a/aliyun-net-sdk-core/Profile/DefaultProfile.cs
+++ b/aliyun-net-sdk-core/Profile/DefaultProfile.cs
@@ -108,6 +108,7 @@ namespace Aliyun.Acs.Core.Profile
         public void AddEndpoint(string endpointName, string regionId, string product, string domain,
             bool isNeverExpire = false)
         {
+            EndpointUserConfig.AddEndpoint(product, regionId, domain);
             endpointResolve.AddEndpoint(endpointName, regionId, product, domain, isNeverExpire);
         }
 

--- a/aliyun-net-sdk-core/Regions/EndpointUserConfig.cs
+++ b/aliyun-net-sdk-core/Regions/EndpointUserConfig.cs
@@ -1,0 +1,38 @@
+using System.Collections.Generic;
+
+namespace Aliyun.Acs.Core.Regions
+{
+    public static class EndpointUserConfig
+    {
+        public static Dictionary<string, ProductDomain> endpoints = new Dictionary<string, ProductDomain>() { };
+
+        public static void AddEndpoint(string product, string regionId, string domain)
+        {
+            if (product == null || regionId == null || domain == null)
+            {
+                return;
+            }
+            string key = product + "_" + regionId;
+            if (!endpoints.ContainsKey(key))
+            {
+                ProductDomain productDomain = new ProductDomain(product, domain);
+                endpoints.Add(key, productDomain);
+            }
+        }
+
+        public static ProductDomain GetProductDomain(string product, string regionId)
+        {
+            string key = product + "_" + regionId;
+            ProductDomain productDomain = null;
+            if (endpoints.ContainsKey(key))
+            {
+                productDomain = endpoints[key];
+            }
+            return productDomain;
+        }
+
+        public static void Clear(){
+            endpoints = new Dictionary<string, ProductDomain>(){};
+        }
+    }
+}


### PR DESCRIPTION
1. 新增 EndpointUserConfig 类，存储用户自定义的 endpoint map 数据.
2. 在用户未 setEndpoint 时，即 request.ProductDomain 为 null 时，从自定义 endpoint map 中查找.
3. 在自定义 endpoint map 中未找到，则使用后续寻址逻辑.
